### PR TITLE
Fixing cokery selection (and modules)

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -1,9 +1,6 @@
-require "defines"
-
-
 
 script.on_event(defines.events.on_built_entity, function(event)
-	if event.created_entity.name == "tf-cokery-dummy" then
+	if event.created_entity.name == "tf-cokery" then
 		game.get_surface("nauvis").create_entity{name = "tf-cokery", position = event.created_entity.position, force = game.forces.player}
 		event.created_entity.destroy()
 	end

--- a/control.lua
+++ b/control.lua
@@ -1,7 +1,7 @@
 
 script.on_event(defines.events.on_built_entity, function(event)
 	if event.created_entity.name == "tf-cokery" then
-		game.get_surface("nauvis").create_entity{name = "tf-cokery", position = event.created_entity.position, force = game.forces.player}
+		game.surfaces["nauvis"].create_entity{name = "tf-cokery", position = event.created_entity.position, force = game.forces.player}
 		event.created_entity.destroy()
 	end
 end)

--- a/info.json
+++ b/info.json
@@ -1,11 +1,10 @@
 {
   "name": "Treefarm-AC",
-  "version": "0.2.3",
+  "version": "0.3.0",
+  "factorio_version": "0.14",
   "title": "Treefarm-AC",
-  "author": "drs, Blu3wolf",
-  "homepage": "_",
-  "dependencies": ["base >= 0.12.11","Treefarm-Lite >= 0.2.1"],
-  "description": "This mod adds optional content to the treefarm like coke production, fertilizer production and biomass.
-
-Published under the GPLv2"
+  "author": "drs, Blu3wolf, Treefarm Team",
+  "homepage": "https://github.com/Blu3wolf/Treefarm-AC",
+  "dependencies": ["base >= 0.14.0","Treefarm-Lite >= 0.5.1"],
+  "description": "This mod adds optional content to the treefarm like coke production, fertilizer production and biomass.Published under the GPLv3"
 }

--- a/prototypes/buildingPrototypes.lua
+++ b/prototypes/buildingPrototypes.lua
@@ -100,28 +100,6 @@ data:extend(
 --ENTITIES
 	-- COKERY
 	{
-    type = "container",
-    name = "tf-cokery-dummy",
-    icon = "__Treefarm-AC__/graphics/icons/cokery.png",
-    flags = {"placeable-neutral","placeable-player", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "tf-cokery"},
-		max_health = 200,
-		corpse = "big-remnants",
-		resistances = {{type = "fire", percent = 70}},
-		collision_box = {{-1.4, -2.0}, {1.4, 2.4}},
-		selection_box = {{-1.5, -2.5}, {1.5, 2.5}},
-    inventory_size = 1,
-    picture =
-    {
-      filename = "__Treefarm-AC__/graphics/entities/cokery/cokery-idle.png",
-      priority = "extra-high",
-      width = 100,
-      height = 160,
-      shift = {0.0, 0.0}
-    }
-  },
-
-	{
 		type = "assembling-machine",
 		name = "tf-cokery",
 		icon = "__Treefarm-AC__/graphics/icons/cokery.png",
@@ -133,7 +111,10 @@ data:extend(
 		resistances = {{type = "fire", percent = 70}},
 		collision_box = {{-1.4, -2.0}, {1.4, 2.4}},
 		selection_box = {{-1.5, -2.5}, {1.5, 2.5}},
+		module_specification =
+		{
 		module_slots = 2,
+		},
 		allowed_effects = {"consumption", "speed"},
 
 		animation =
@@ -219,7 +200,10 @@ data:extend(
 		max_health = 100,
 		corpse = "big-remnants",
 		dying_explosion = "medium-explosion",
+		module_specification =
+		{
 		module_slots = 1,
+		},
 		resistances = {{type = "fire",percent = 70}},
 		working_sound = {
 							sound = {
@@ -349,7 +333,10 @@ data:extend(
 		corpse = "big-remnants",
 		collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
 		selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+		module_specification =
+		{
 		module_slots = 2,
+		},
 		allowed_effects = {"consumption", "speed", "productivity", "pollution"},
 		animation =
 		{


### PR DESCRIPTION
In the process of trying to fix the cokery because I couldn't select it with the deconstruction planner or the blueprint planner, I messed with some of the code, I've tested it in 14.3 and multiplayer with 2 others, and my changes to these files have appeared to have fixed all the problems I've been having with the cokery and also some of the code that seems to not be working properly with the modules in some of the buildings.
